### PR TITLE
Register cortex_gateway_failed_authentications_total

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	jwtSecret    string
-	authFailures = prometheus.NewCounterVec(prometheus.CounterOpts{
+	authFailures = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "cortex_gateway",
 		Name:      "failed_authentications_total",
 		Help:      "The total number of failed authentications.",


### PR DESCRIPTION
I'm trying to troubleshoot why my JWT header is being rejected by cortex-gateway, and looking through the code I noticed that I _should_ see a metric like `cortex_gateway_failed_authentications_total{reason="token_not_valid"}`. But instead I saw nothing! And since I'm running v1.0.0 I don't see the log message added recently either.

Then I noticed that while `authSuccess` uses `promauto.NewCounterVec`, `authFailures` uses `prometheus.NewCounterVec`. The difference is that the `promauto` flavour will automatically register the metric, while the other requires it to be registered separately.

This should fix that metric not being recorded.